### PR TITLE
Update typo in build.properties

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-sbt.verion=0.13.11
+sbt.version=0.13.11


### PR DESCRIPTION
Fix to issue #1 
sbt.version is not spelled correctly. This change corrects the typo.
